### PR TITLE
Fix qtable init, handle vps options error

### DIFF
--- a/plebnet/agent/core.py
+++ b/plebnet/agent/core.py
@@ -57,12 +57,8 @@ def setup(args):
         if providers.has_key('proxhost'):
             del providers["proxhost"]
 
-        # Read the Qtable after deleting proxhost (URL doesn't work)
+        # Create QTable if it does not exist
         qtable.read_dictionary(providers)
-
-        qtable.init_qtable_and_environment(providers)
-
-    qtable.write_dictionary()
 
     if args.exit_node:
         logger.log("Running as exitnode")

--- a/plebnet/agent/qtable.py
+++ b/plebnet/agent/qtable.py
@@ -150,7 +150,6 @@ class QTable:
             "providers_offers": self.providers_offers,
             "self_state": next_state,
             "transaction_hash": transaction_hash
-
         }
         filename = os.path.join(user_config_dir(), 'Child_QTable.json')
         with open(filename, 'w') as json_file:

--- a/plebnet/controllers/cloudomate_controller.py
+++ b/plebnet/controllers/cloudomate_controller.py
@@ -98,10 +98,12 @@ def setrootpw(provider, password):
 
 
 def options(provider):
+    opts = []
     try:
-        return provider.get_options()
+        opts = provider.get_options()
     except:
-        logger.log("Cloudomate options failed")
+        logger.log(provider.get_metadata()[0] + " options failed", "cloudomate_controller")
+    return opts
 
 
 def get_network_fee():


### PR DESCRIPTION
This PR fixes two issues:

- When a child is created, the QTable has already been initialized by the parent, so it is not desirable to replace it by a new QTable in `plebnet setup`.

- When vps options fails, an empty array should be returned instead of NoneType.