### PR TITLE
Add simple moving average market strategy

### DIFF
--- a/plebnet/agent/core.py
+++ b/plebnet/agent/core.py
@@ -24,6 +24,7 @@ from plebnet.utilities import logger, fake_generator
 
 from plebnet.agent.strategies.last_day_sell import LastDaySell
 from plebnet.agent.strategies.constant_sell import ConstantSell
+from plebnet.agent.strategies.simple_moving_average import SimpleMovingAverage
 from plebnet.utilities.btc import satoshi_to_btc
 
 settings = plebnet_settings.get_instance()
@@ -31,7 +32,8 @@ log_name = "agent.core"  # Used for identifying the origin of the log message.
 config = None  # Used to store the configuration and only load once.
 strategies = {
     'last_day_sell': LastDaySell,
-    'constant_sell': ConstantSell
+    'constant_sell': ConstantSell,
+    'simple_moving_average': SimpleMovingAverage
 }
 qtable = None  # Used to store the QTable of the agent and only load once.
 

--- a/plebnet/agent/strategies/constant_sell.py
+++ b/plebnet/agent/strategies/constant_sell.py
@@ -1,8 +1,11 @@
 from plebnet.controllers import wallet_controller
+from plebnet.utilities import logger
 from plebnet.utilities.btc import satoshi_to_btc
 from strategy import Strategy
 
 from plebnet.settings import plebnet_settings
+
+log_name = "agent.strategies.constant_sell"
 
 
 class ConstantSell(Strategy):
@@ -17,11 +20,16 @@ class ConstantSell(Strategy):
             attempt_purchase()
 
     def sell_reputation(self):
-        self.update_offer()
+        available_mb = self.get_available_mb()
+        if available_mb == 0:
+            logger.log("No MB available", log_name)
+            return
+        self.update_offer(available_mb)
 
-    def create_offer(self, timeout):
+    def create_offer(self, amount_mb, timeout):
         """
         Retrieve the price of the chosen server to buy and make a new offer on the Tribler marketplace.
+        :param amount_mb:
         :param timeout: offer to
         :return: None
         """
@@ -30,5 +38,5 @@ class ConstantSell(Strategy):
         wallet = wallet_controller.TriblerWallet(plebnet_settings.get_instance().wallets_testnet_created())
         (provider, option, _) = self.config.get('chosen_provider')
         btc_balance = satoshi_to_btc(wallet.get_balance())
-        btc_price = self.get_replication_price(provider, option) * self.target_vps_count - btc_balance
-        self.place_offer(btc_price, timeout, self.config)
+        btc_price = max(self.get_replication_price(provider, option) * self.target_vps_count - btc_balance, 0)
+        self.place_offer(amount_mb, btc_price, timeout, self.config)

--- a/plebnet/agent/strategies/last_day_sell.py
+++ b/plebnet/agent/strategies/last_day_sell.py
@@ -1,8 +1,11 @@
 from plebnet.controllers import wallet_controller
+from plebnet.utilities import logger
 from plebnet.utilities.btc import satoshi_to_btc
 from strategy import Strategy
 
 from plebnet.settings import plebnet_settings
+
+log_name = "agent.strategies.last_day_sell"
 
 
 class LastDaySell(Strategy):
@@ -18,11 +21,16 @@ class LastDaySell(Strategy):
 
     def sell_reputation(self):
         if self.config.time_to_expiration() <= plebnet_settings.TIME_IN_DAY:
-            self.update_offer()
+            available_mb = self.get_available_mb()
+            if available_mb == 0:
+                logger.log("No MB available", log_name)
+                return
+            self.update_offer(available_mb)
 
-    def create_offer(self, timeout):
+    def create_offer(self, amount_mb, timeout):
         """
         Retrieve the price of the chosen server to buy and make a new offer on the Tribler marketplace.
+        :param amount_mb: Amount of reputation to sell
         :param timeout: offer to
         :return: None
         """
@@ -31,5 +39,5 @@ class LastDaySell(Strategy):
         wallet = wallet_controller.TriblerWallet(plebnet_settings.get_instance().wallets_testnet_created())
         (provider, option, _) = self.config.get('chosen_provider')
         btc_balance = satoshi_to_btc(wallet.get_balance())
-        btc_price = self.get_replication_price(provider, option) * self.target_vps_count - btc_balance
-        self.place_offer(btc_price, timeout, self.config)
+        btc_price = max(self.get_replication_price(provider, option) * self.target_vps_count - btc_balance, 0)
+        self.place_offer(amount_mb, btc_price, timeout, self.config)

--- a/plebnet/agent/strategies/simple_moving_average.py
+++ b/plebnet/agent/strategies/simple_moving_average.py
@@ -32,7 +32,8 @@ class SimpleMovingAverage(Strategy):
         if os.path.exists(filename):
             with open(filename, 'r') as json_file:
                 data = json.load(json_file)
-                self.process_last_bid(data['bid'], data['time_accumulated'])
+                self.time_accumulated = data['time_accumulated']
+                self.process_last_bid(data['bid'], data['time_change'])
 
     def process_last_bid(self, bid, bid_time):
         if bid is None:
@@ -55,6 +56,7 @@ class SimpleMovingAverage(Strategy):
         with open(filename, 'w') as json_file:
             json.dump({
                 'time_accumulated': self.time_accumulated,
+                'time_change': self.time_change,
                 'bid': self.bid
             }, json_file)
 

--- a/plebnet/agent/strategies/simple_moving_average.py
+++ b/plebnet/agent/strategies/simple_moving_average.py
@@ -5,6 +5,7 @@ from appdirs import user_config_dir
 
 from plebnet.agent.strategies.last_day_sell import LastDaySell
 from plebnet.controllers import market_controller
+from plebnet.utilities import logger
 from strategy import Strategy
 from datetime import datetime, timedelta
 from math import sqrt
@@ -12,13 +13,17 @@ from math import sqrt
 
 MAX_ACCUMULATION_TIME = 3*24*60
 ITERATION_TIME_DIFF = 5
+log_name = "agent.strategies.simple_moving_average"
 
 
 class SimpleMovingAverage(Strategy):
     def __init__(self):
         Strategy.__init__(self)
         self.time_accumulated = 0
-        self.transactions = []
+        self.bid = None
+        self.time_change = 0
+        self.transactions = market_controller.transactions()
+        self.read_last_iteration_info()
 
     def read_last_iteration_info(self):
         config_dir = user_config_dir()
@@ -26,7 +31,21 @@ class SimpleMovingAverage(Strategy):
         if os.path.exists(filename):
             with open(filename, 'r') as json_file:
                 data = json.load(json_file)
-                self.time_accumulated = data['time_accumulated']
+                self.process_last_bid(data['bid'], data['time_accumulated'])
+
+    def process_last_bid(self, bid, bid_time):
+        if bid is None:
+            return
+
+        fulfilled_part = 0.0
+        for transaction in self.transactions:
+            if transaction['trader_id'] == bid['trader_id'] and \
+               transaction['order_number'] == bid['order_number']:
+                if transaction['transferred']['second']['amount'] > 0:
+                    fulfilled_part = float(transaction['transferred']['second']['amount']) / \
+                                     transaction['assets']['second']['amount']
+
+        self.time_accumulated += int(bid_time*(1.0-fulfilled_part))
 
     def write_iteration_info(self):
         config_dir = user_config_dir()
@@ -35,16 +54,17 @@ class SimpleMovingAverage(Strategy):
         with open(filename, 'w') as json_file:
             json.dump({
                 'time_accumulated': self.time_accumulated,
+                'bid': self.bid
             }, json_file)
 
     def apply(self):
-        self.transactions = market_controller.transactions()
         if len(self.transactions) == 0:  # Fallback to last_day_sell if can't apply strategy
+            logger.log("No transactions saved. Defaulting to Last Day Sell strategy", log_name)
             return LastDaySell().apply()
         self.time_accumulated += ITERATION_TIME_DIFF
-        from plebnet.agent.core import attempt_purchase
-        self.sell_reputation()
+        self.bid = self.sell_reputation()
         self.write_iteration_info()
+        from plebnet.agent.core import attempt_purchase
         attempt_purchase()
 
     def get_closing_transactions(self):
@@ -74,18 +94,25 @@ class SimpleMovingAverage(Strategy):
         moving_average = 0.0
         for date, transaction in closing_transactions.items():
             price = self.calculate_price(transaction)
-            moving_average += price / len(closing_transactions)
+            moving_average += price
+        moving_average /= len(closing_transactions)
 
         variance = 0.0
         for date, transaction in closing_transactions.items():
             price = self.calculate_price(transaction)
-            variance += (price - moving_average)**2 / len(closing_transactions)
+            variance += (price - moving_average)**2
+        if variance != 0:
+            variance /= (len(closing_transactions) - 1)
         std_deviation = sqrt(variance)
 
         return moving_average, std_deviation
 
     def get_reputation_gain_rate(self, time_unit_minutes=ITERATION_TIME_DIFF):
-        return self.get_available_mb()/self.time_accumulated * time_unit_minutes
+        return self.get_available_mb() * time_unit_minutes / self.time_accumulated
+
+    def update_accumulated_time(self, parts_sold):
+        self.time_change = min(self.time_accumulated, ITERATION_TIME_DIFF*parts_sold)
+        self.time_accumulated -= self.time_change
 
     def sell_reputation(self):
         moving_average, std_deviation = self.calculate_moving_average_data()
@@ -95,22 +122,22 @@ class SimpleMovingAverage(Strategy):
         last_price = self.calculate_price(self.transactions[-1])
         if last_price < moving_average:
             if self.time_accumulated <= MAX_ACCUMULATION_TIME:  # Accumulation zone
-                return
-            self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF, 0)
+                return None
+            self.update_accumulated_time(1)
         else:
             if last_price >= moving_average + 5 * std_deviation:  # HUGE SPIKE - sell everything
                 mb_to_sell = available_mb
-                self.time_accumulated = 0
+                self.update_accumulated_time(self.time_accumulated)
             elif last_price >= moving_average + 3*std_deviation:  # Really Big spike - sell 3 times production rate
-                mb_to_sell = min(self.get_reputation_gain_rate() * 3, available_mb)
-                self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF * 3, 0)
+                mb_to_sell = min(mb_to_sell * 3, available_mb)
+                self.update_accumulated_time(3)
             elif last_price >= moving_average + 2 * std_deviation:  # Big spike - sell 2 times production rate
-                mb_to_sell = min(self.get_reputation_gain_rate() * 2, available_mb)
-                self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF * 2, 0)
+                mb_to_sell = min(mb_to_sell * 2, available_mb)
+                self.update_accumulated_time(2)
             else:
-                self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF, 0)
+                self.update_accumulated_time(1)
 
-        self.update_offer(mb_to_sell, ITERATION_TIME_DIFF*60)
+        return self.update_offer(mb_to_sell, ITERATION_TIME_DIFF*60)
 
     def create_offer(self, amount_mb, timeout):
         """
@@ -124,4 +151,4 @@ class SimpleMovingAverage(Strategy):
         (provider, option, _) = self.config.get('chosen_provider')
         last_price = self.calculate_price(self.transactions[-1])
         btc_price = int(last_price * amount_mb)
-        self.place_offer(amount_mb, btc_price, timeout, self.config)
+        return self.place_offer(amount_mb, btc_price, timeout, self.config)

--- a/plebnet/agent/strategies/simple_moving_average.py
+++ b/plebnet/agent/strategies/simple_moving_average.py
@@ -1,0 +1,127 @@
+import json
+import os
+
+from appdirs import user_config_dir
+
+from plebnet.agent.strategies.last_day_sell import LastDaySell
+from plebnet.controllers import market_controller
+from strategy import Strategy
+from datetime import datetime, timedelta
+from math import sqrt
+
+
+MAX_ACCUMULATION_TIME = 3*24*60
+ITERATION_TIME_DIFF = 5
+
+
+class SimpleMovingAverage(Strategy):
+    def __init__(self):
+        Strategy.__init__(self)
+        self.time_accumulated = 0
+        self.transactions = []
+
+    def read_last_iteration_info(self):
+        config_dir = user_config_dir()
+        filename = os.path.join(config_dir, 'simple_moving_average.json')
+        if os.path.exists(filename):
+            with open(filename, 'r') as json_file:
+                data = json.load(json_file)
+                self.time_accumulated = data['time_accumulated']
+
+    def write_iteration_info(self):
+        config_dir = user_config_dir()
+        filename = os.path.join(config_dir, 'simple_moving_average.json')
+
+        with open(filename, 'w') as json_file:
+            json.dump({
+                'time_accumulated': self.time_accumulated,
+            }, json_file)
+
+    def apply(self):
+        self.transactions = market_controller.transactions()
+        if len(self.transactions) == 0:  # Fallback to last_day_sell if can't apply strategy
+            return LastDaySell().apply()
+        self.time_accumulated += ITERATION_TIME_DIFF
+        from plebnet.agent.core import attempt_purchase
+        self.sell_reputation()
+        self.write_iteration_info()
+        attempt_purchase()
+
+    def get_closing_transactions(self):
+        closing_transactions = {}
+
+        for transaction in self.transactions:
+            date = datetime.fromtimestamp(transaction['timestamp'])
+            date_str = date.strftime('%Y-%m-%d')
+            if date_str in closing_transactions:
+                existing_date = datetime.fromtimestamp(closing_transactions[date_str]['timestamp'])
+                if date > existing_date:
+                    closing_transactions[date_str] = transaction
+            else:
+                today = datetime.today().date()
+                thirty_days_ago = (datetime.today() - timedelta(days=30)).date()
+                if today > date.date() > thirty_days_ago:
+                    closing_transactions[date_str] = transaction
+
+        return closing_transactions
+
+    def calculate_price(self, transaction):
+        return float(transaction['assets']['first']['amount'])/transaction['assets']['second']['amount']
+
+    def calculate_moving_average_data(self):
+        closing_transactions = self.get_closing_transactions()
+
+        moving_average = 0.0
+        for date, transaction in closing_transactions.items():
+            price = self.calculate_price(transaction)
+            moving_average += price / len(closing_transactions)
+
+        variance = 0.0
+        for date, transaction in closing_transactions.items():
+            price = self.calculate_price(transaction)
+            variance += (price - moving_average)**2 / len(closing_transactions)
+        std_deviation = sqrt(variance)
+
+        return moving_average, std_deviation
+
+    def get_reputation_gain_rate(self, time_unit_minutes=ITERATION_TIME_DIFF):
+        return self.get_available_mb()/self.time_accumulated * time_unit_minutes
+
+    def sell_reputation(self):
+        moving_average, std_deviation = self.calculate_moving_average_data()
+
+        available_mb = self.get_available_mb()
+        mb_to_sell = self.get_reputation_gain_rate()
+        last_price = self.calculate_price(self.transactions[-1])
+        if last_price < moving_average:
+            if self.time_accumulated <= MAX_ACCUMULATION_TIME:  # Accumulation zone
+                return
+            self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF, 0)
+        else:
+            if last_price >= moving_average + 5 * std_deviation:  # HUGE SPIKE - sell everything
+                mb_to_sell = available_mb
+                self.time_accumulated = 0
+            elif last_price >= moving_average + 3*std_deviation:  # Really Big spike - sell 3 times production rate
+                mb_to_sell = min(self.get_reputation_gain_rate() * 3, available_mb)
+                self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF * 3, 0)
+            elif last_price >= moving_average + 2 * std_deviation:  # Big spike - sell 2 times production rate
+                mb_to_sell = min(self.get_reputation_gain_rate() * 2, available_mb)
+                self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF * 2, 0)
+            else:
+                self.time_accumulated = max(self.time_accumulated - ITERATION_TIME_DIFF, 0)
+
+        self.update_offer(mb_to_sell, ITERATION_TIME_DIFF*60)
+
+    def create_offer(self, amount_mb, timeout):
+        """
+        Retrieve the price of the chosen server to buy and make a new offer on the Tribler marketplace.
+        :param amount_mb:
+        :param timeout: offer to
+        :return: None
+        """
+        if not self.config.get('chosen_provider'):
+            return
+        (provider, option, _) = self.config.get('chosen_provider')
+        last_price = self.calculate_price(self.transactions[-1])
+        btc_price = int(last_price * amount_mb)
+        self.place_offer(amount_mb, btc_price, timeout, self.config)

--- a/plebnet/agent/strategies/simple_moving_average.py
+++ b/plebnet/agent/strategies/simple_moving_average.py
@@ -6,6 +6,7 @@ from appdirs import user_config_dir
 from plebnet.agent.strategies.last_day_sell import LastDaySell
 from plebnet.controllers import market_controller
 from plebnet.utilities import logger
+from plebnet.utilities.btc import satoshi_to_btc
 from strategy import Strategy
 from datetime import datetime, timedelta
 from math import sqrt
@@ -150,5 +151,5 @@ class SimpleMovingAverage(Strategy):
             return
         (provider, option, _) = self.config.get('chosen_provider')
         last_price = self.calculate_price(self.transactions[-1])
-        btc_price = int(last_price * amount_mb)
+        btc_price = satoshi_to_btc(last_price * amount_mb)
         return self.place_offer(amount_mb, btc_price, timeout, self.config)

--- a/plebnet/agent/strategies/strategy.py
+++ b/plebnet/agent/strategies/strategy.py
@@ -54,8 +54,8 @@ class Strategy():
         """
         if self.config.time_since_offer() > timeout:
             logger.log("Calculating new offer", log_name)
-            self.create_offer(mb_amount, timeout)
             self.config.save()
+            return self.create_offer(mb_amount, timeout)
 
     def place_offer(self, mb_amount, chosen_est_price, timeout, config):
         """

--- a/plebnet/agent/strategies/strategy.py
+++ b/plebnet/agent/strategies/strategy.py
@@ -34,27 +34,30 @@ class Strategy():
         pass
 
     @abstractmethod
-    def create_offer(self, timeout):
+    def create_offer(self, amount_mb, timeout):
         """
         Creates a new order in the market, with parameters depending on the implementing strategy
         :return:
         """
         pass
 
+    def get_available_mb(self):
+        return market_controller.get_balance('MB')
+
     @staticmethod
     def get_replication_price(vps_provider, option, vpn_provider='azirevpn'):
         return (calculate_price(vps_provider, option) + calculate_price_vpn(vpn_provider)) * BTC_FLUCTUATION_MARGIN
 
-    def update_offer(self, timeout=plebnet_settings.TIME_IN_HOUR):
+    def update_offer(self, mb_amount, timeout=plebnet_settings.TIME_IN_HOUR):
         """
-        Check if an hour as passed since the last offer made, if passed create a new offer.
+        Check if "timeout" has passed since the last offer made, if passed create a new offer.
         """
         if self.config.time_since_offer() > timeout:
             logger.log("Calculating new offer", log_name)
-            self.create_offer(timeout)
+            self.create_offer(mb_amount, timeout)
             self.config.save()
 
-    def place_offer(self, chosen_est_price, timeout, config):
+    def place_offer(self, mb_amount, chosen_est_price, timeout, config):
         """
         Sell all available MB for the chosen estimated price on the Tribler market.
         :param config: config
@@ -62,19 +65,15 @@ class Strategy():
         :param chosen_est_price: Target amount of BTC to receive
         :return: success of offer placement
         """
-        available_mb = market_controller.get_balance('MB')
-        if available_mb == 0:
-            logger.log("No MB available", log_name)
+        if chosen_est_price == 0:
             return False
         config.bump_offer_date()
 
         coin = 'TBTC' if plebnet_settings.get_instance().wallets_testnet() else 'BTC'
 
-        logger.log("Placing offer for %s MB / %s %s" % (available_mb, chosen_est_price, coin), log_name)
-
-        config.set('last_offer', {coin: chosen_est_price, 'MB': available_mb})
+        config.set('last_offer', {coin: chosen_est_price, 'MB': mb_amount})
         return market_controller.put_bid(first_asset_amount=btc_to_satoshi(chosen_est_price),
                                          first_asset_type=coin,
-                                         second_asset_amount=available_mb,
+                                         second_asset_amount=mb_amount,
                                          second_asset_type='MB',
                                          timeout=timeout)

--- a/plebnet/agent/strategies/strategy.py
+++ b/plebnet/agent/strategies/strategy.py
@@ -59,13 +59,14 @@ class Strategy():
 
     def place_offer(self, mb_amount, chosen_est_price, timeout, config):
         """
-        Sell all available MB for the chosen estimated price on the Tribler market.
+        Sells the received MB amount for the chosen estimated price on the Tribler market.
+        :param mb_amount: Amount of MB to sell
         :param config: config
         :param timeout: timeout of the offer to place
         :param chosen_est_price: Target amount of BTC to receive
         :return: success of offer placement
         """
-        if chosen_est_price == 0:
+        if chosen_est_price == 0 or mb_amount == 0:
             return False
         config.bump_offer_date()
 

--- a/plebnet/controllers/market_controller.py
+++ b/plebnet/controllers/market_controller.py
@@ -104,6 +104,12 @@ def bids():
     return r.json()['bids']
 
 
+def transactions():
+    url = 'http://localhost:8085/market/transactions'
+    r = requests.get(url)
+    return r.json()['transactions']
+
+
 def has_matchmakers():
     """
     Checks if there are any matchmakers.

--- a/plebnet/twisted/plugins/plebnet_plugin.py
+++ b/plebnet/twisted/plugins/plebnet_plugin.py
@@ -106,6 +106,10 @@ class MarketServiceMaker(object):
             msg("Enabling dummy wallets")
             config.set_dummy_wallets_enabled(True)
 
+        # Enable record transactions
+        msg("Enabling record transactions")
+        config.set_record_transactions(True)
+
         # Minimize functionality enabled for plebnet
         # For now, config taken from market_plugin in devos tribler repo
         config.set_http_api_enabled(True)

--- a/tests/agent/strategies/test_constant_sell.py
+++ b/tests/agent/strategies/test_constant_sell.py
@@ -28,17 +28,36 @@ class TestConstantSell(unittest.TestCase):
         core.attempt_purchase = self.ap
 
     def test_sell_reputation(self):
+        amount_mb = 987
         self.strategy = ConstantSell()
         self.uo = self.strategy.update_offer
+        self.available = self.strategy.get_available_mb
 
         self.strategy.update_offer = MagicMock()
+        self.strategy.get_available_mb = MagicMock(return_value=amount_mb)
 
         self.strategy.sell_reputation()
-        self.strategy.update_offer.assert_called_once()
+        self.strategy.update_offer.assert_called_once_with(amount_mb)
 
         self.strategy.update_offer = self.uo
+        self.strategy.get_available_mb = self.available
+
+    def test_sell_reputation_no_mb(self):
+        self.strategy = ConstantSell()
+        self.uo = self.strategy.update_offer
+        self.available = self.strategy.get_available_mb
+
+        self.strategy.update_offer = MagicMock()
+        self.strategy.get_available_mb = MagicMock(return_value=0)
+
+        self.strategy.sell_reputation()
+        self.strategy.update_offer.assert_not_called()
+
+        self.strategy.update_offer = self.uo
+        self.strategy.get_available_mb = self.available
 
     def test_create_offer_no_provider(self):
+        amount_mb = 1
         self.strategy = ConstantSell()
         self.po = self.strategy.place_offer
         self.grp = self.strategy.get_replication_price
@@ -47,13 +66,14 @@ class TestConstantSell(unittest.TestCase):
         self.strategy.get_replication_price = MagicMock()
         self.strategy.config.get = MagicMock(return_value=None)
 
-        self.strategy.create_offer(plebnet_settings.TIME_IN_HOUR)
+        self.strategy.create_offer(amount_mb, plebnet_settings.TIME_IN_HOUR)
         self.strategy.place_offer.assert_not_called()
 
         self.strategy.place_offer = self.po
         self.strategy.get_replication_price = self.grp
 
     def test_create_offer_with_provider(self):
+        amount_mb = 1
         self.strategy = ConstantSell()
         self.po = self.strategy.place_offer
         self.grp = self.strategy.get_replication_price
@@ -62,7 +82,7 @@ class TestConstantSell(unittest.TestCase):
         self.strategy.get_replication_price = MagicMock(return_value=3)
         self.strategy.config.get = MagicMock(return_value=('prov', 'opt', 'test'))
 
-        self.strategy.create_offer(plebnet_settings.TIME_IN_HOUR)
+        self.strategy.create_offer(amount_mb, plebnet_settings.TIME_IN_HOUR)
         self.strategy.place_offer.assert_called_once()
 
         self.strategy.place_offer = self.po

--- a/tests/agent/strategies/test_last_day_sell.py
+++ b/tests/agent/strategies/test_last_day_sell.py
@@ -40,18 +40,23 @@ class TestLastDaySell(unittest.TestCase):
         self.strategy.update_offer = self.uo
 
     def test_sell_reputation_on_last_day(self):
+        amount_mb = 123
         self.strategy = LastDaySell()
         self.uo = self.strategy.update_offer
+        self.available = self.strategy.get_available_mb
 
         self.strategy.config.time_to_expiration = MagicMock(return_value=plebnet_settings.TIME_IN_DAY - 1)
         self.strategy.update_offer = MagicMock()
+        self.strategy.get_available_mb = MagicMock(return_value=amount_mb)
 
         self.strategy.sell_reputation()
-        self.strategy.update_offer.assert_called_once()
+        self.strategy.update_offer.assert_called_once_with(amount_mb)
 
         self.strategy.update_offer = self.uo
+        self.strategy.get_available_mb = self.available
 
     def test_create_offer_no_provider(self):
+        amount_mb = 100
         self.strategy = LastDaySell()
         self.po = self.strategy.place_offer
         self.grp = self.strategy.get_replication_price
@@ -60,13 +65,14 @@ class TestLastDaySell(unittest.TestCase):
         self.strategy.get_replication_price = MagicMock()
         self.strategy.config.get = MagicMock(return_value=None)
 
-        self.strategy.create_offer(plebnet_settings.TIME_IN_HOUR)
+        self.strategy.create_offer(amount_mb, plebnet_settings.TIME_IN_HOUR)
         self.strategy.place_offer.assert_not_called()
 
         self.strategy.place_offer = self.po
         self.strategy.get_replication_price = self.grp
 
     def test_create_offer_with_provider(self):
+        amount_mb = 100
         self.strategy = LastDaySell()
         self.po = self.strategy.place_offer
         self.grp = self.strategy.get_replication_price
@@ -75,7 +81,7 @@ class TestLastDaySell(unittest.TestCase):
         self.strategy.get_replication_price = MagicMock(return_value=3)
         self.strategy.config.get = MagicMock(return_value=('prov', 'opt', 'test'))
 
-        self.strategy.create_offer(plebnet_settings.TIME_IN_HOUR)
+        self.strategy.create_offer(amount_mb, plebnet_settings.TIME_IN_HOUR)
         self.strategy.place_offer.assert_called_once()
 
         self.strategy.place_offer = self.po

--- a/tests/agent/strategies/test_simple_moving_average.py
+++ b/tests/agent/strategies/test_simple_moving_average.py
@@ -1,0 +1,314 @@
+import time
+import unittest
+
+from mock.mock import MagicMock
+
+from plebnet.agent import core
+from plebnet.agent.strategies.last_day_sell import LastDaySell
+from plebnet.agent.strategies.simple_moving_average import SimpleMovingAverage, MAX_ACCUMULATION_TIME, \
+                                                            ITERATION_TIME_DIFF
+from plebnet.controllers import market_controller
+
+from plebnet.settings import plebnet_settings
+
+
+class TestSimpleMovingAverage(unittest.TestCase):
+
+    def setUp(self):
+        self.read = SimpleMovingAverage.read_last_iteration_info
+        self.tra = market_controller.transactions
+        SimpleMovingAverage.read_last_iteration_info = MagicMock()
+        market_controller.transactions = MagicMock()
+        self.strategy = SimpleMovingAverage()
+
+        self.strategy.transactions = [
+            {
+                'trader_id': 1,
+                'order_number': 1,
+                'assets': {
+                    'first': {
+                        'amount': 10,
+                        'type': 'BTC'
+                    },
+                    'second': {
+                        'amount': 10,
+                        'type': 'MB'
+                    }
+                },
+                'transferred': {
+                    'first': {
+                        'amount': 10,
+                        'type': 'BTC'
+                    },
+                    'second': {
+                        'amount': 10,
+                        'type': 'MB'
+                    }
+                }
+            }
+        ]
+
+    def tearDown(self):
+        del self.strategy
+        SimpleMovingAverage.read_last_iteration_info = self.read
+        market_controller.transactions = self.tra
+
+    def test_process_last_bid_fulfilled(self):
+        bid_time = 10
+        initial_time = 7
+        self.strategy.time_accumulated = initial_time
+
+        self.strategy.process_last_bid(self.strategy.transactions[0], bid_time)
+        self.assertEqual(self.strategy.time_accumulated, initial_time)
+
+        self.strategy.transactions[0]['transferred']['first']['amount'] /= 2
+        self.strategy.transactions[0]['transferred']['second']['amount'] /= 2
+
+        self.strategy.process_last_bid(self.strategy.transactions[0], bid_time)
+        self.assertEqual(self.strategy.time_accumulated, initial_time + bid_time/2)
+
+    def test_process_last_bid_not_fulfilled(self):
+        bid_time = 10
+        initial_time = 5
+        self.strategy.time_accumulated = initial_time
+        self.strategy.process_last_bid({'trader_id': 0, 'order_number': 0}, bid_time)
+        self.assertEqual(self.strategy.time_accumulated, initial_time + bid_time)
+
+    def test_fallback_to_last_day(self):
+        self.strategy.transactions = []
+
+        LastDaySell.apply = MagicMock()
+        self.strategy.apply()
+        LastDaySell.apply.assert_called_once()
+
+    def test_apply(self):
+        initial_time = 10
+        self.strategy.time_accumulated = initial_time
+        self.strategy.sell_reputation = MagicMock()
+        self.strategy.write_iteration_info = MagicMock()
+        core.attempt_purchase = MagicMock()
+
+        self.strategy.apply()
+
+        self.assertEqual(self.strategy.time_accumulated, initial_time + ITERATION_TIME_DIFF)
+        self.strategy.sell_reputation.assert_called_once()
+        self.strategy.write_iteration_info.assert_called_once()
+        core.attempt_purchase.assert_called_once()
+
+    def create_transaction(self, timestamp, price=1):
+        return {
+                'trader_id': 1,
+                'order_number': 1,
+                'timestamp': timestamp,
+                'assets': {
+                    'first': {
+                        'amount': 10*price,
+                        'type': 'BTC'
+                    },
+                    'second': {
+                        'amount': 10,
+                        'type': 'MB'
+                    }
+                },
+                'transferred': {
+                    'first': {
+                        'amount': 10*price,
+                        'type': 'BTC'
+                    },
+                    'second': {
+                        'amount': 10,
+                        'type': 'MB'
+                    }
+                }
+            }
+
+    def test_closing_transactions(self):
+        closing_timestamps = []
+        self.strategy.transactions = []
+        num_days = 3
+        for i in range(0, num_days):
+            t1 = time.mktime((2019, 1, 1+i, 15, 0, 0, 0, 0, -1))
+            t2 = time.mktime((2019, 1, 1+i, 20, 0, 0, 0, 0, -1))
+            closing_timestamps.append(t2)
+            self.strategy.transactions.append(self.create_transaction(t1))
+            self.strategy.transactions.append(self.create_transaction(t2))
+
+        closing_transactions = self.strategy.get_closing_transactions()
+
+        self.assertEqual(len(closing_transactions), num_days)
+        for closing_transaction in closing_transactions.values():
+            self.assertTrue(closing_transaction['timestamp'] in closing_timestamps)
+
+    def test_calculate_price(self):
+        price = 5
+        self.assertEqual(price, self.strategy.calculate_price(self.create_transaction(0, price)))
+
+    def test_moving_average(self):
+        self.strategy.get_closing_transactions = MagicMock(return_value={
+            'a': self.create_transaction(time.mktime((2019, 1, 1, 15, 0, 0, 0, 0, -1)), 1),
+            'b': self.create_transaction(time.mktime((2019, 1, 2, 15, 0, 0, 0, 0, -1)), 2),
+            'c': self.create_transaction(time.mktime((2019, 1, 3, 15, 0, 0, 0, 0, -1)), 3)
+        })
+
+        mean, std_dev = self.strategy.calculate_moving_average_data()
+
+        self.assertEqual(mean, 2)
+        self.assertEqual(std_dev, 1)
+
+    def test_get_reputation_gain_rate(self):
+        self.strategy.get_available_mb = MagicMock(return_value=1)
+        self.strategy.time_accumulated = ITERATION_TIME_DIFF
+        self.assertEqual(self.strategy.get_reputation_gain_rate(), 1)
+
+    def test_sell_reputation_below_mean_in_accumulation_zone(self):
+        mean = 5
+        std_dev = 2
+        self.strategy.calculate_moving_average_data = MagicMock(return_value=(mean, std_dev))
+        self.strategy.get_available_mb = MagicMock(return_value=100)
+        self.strategy.get_reputation_gain_rate = MagicMock(return_value=5)
+        self.strategy.calculate_price = MagicMock(return_value=2)
+        self.strategy.update_accumulated_time = MagicMock()
+        self.strategy.update_offer = MagicMock()
+        self.strategy.time_accumulated = MAX_ACCUMULATION_TIME - 1
+
+        self.strategy.sell_reputation()
+
+        self.strategy.calculate_moving_average_data.assert_called_once()
+        self.strategy.get_available_mb.assert_called_once()
+        self.strategy.get_reputation_gain_rate.assert_called_once()
+        self.strategy.calculate_price.assert_called_once()
+        self.strategy.update_accumulated_time.assert_not_called()
+        self.strategy.update_offer.assert_not_called()
+
+    def test_sell_reputation_below_mean_outside_accumulation_zone(self):
+        mean = 5
+        std_dev = 2
+        self.strategy.calculate_moving_average_data = MagicMock(return_value=(mean, std_dev))
+        self.strategy.get_available_mb = MagicMock(return_value=100)
+        self.strategy.get_reputation_gain_rate = MagicMock(return_value=5)
+        self.strategy.calculate_price = MagicMock(return_value=2)
+        self.strategy.update_accumulated_time = MagicMock()
+        self.strategy.update_offer = MagicMock()
+        self.strategy.time_accumulated = MAX_ACCUMULATION_TIME + 1
+
+        self.strategy.sell_reputation()
+
+        self.strategy.calculate_moving_average_data.assert_called_once()
+        self.strategy.get_available_mb.assert_called_once()
+        self.strategy.get_reputation_gain_rate.assert_called_once()
+        self.strategy.calculate_price.assert_called_once()
+        self.strategy.update_accumulated_time.assert_called_with(1)
+        self.strategy.update_offer.assert_called_with(self.strategy.get_reputation_gain_rate(),
+                                                      ITERATION_TIME_DIFF * 60)
+
+    def test_sell_reputation_once_above_mean(self):
+        mean = 5
+        std_dev = 2
+        times_above_mean = 1
+        self.strategy.calculate_moving_average_data = MagicMock(return_value=(mean, std_dev))
+        self.strategy.get_available_mb = MagicMock(return_value=100)
+        self.strategy.get_reputation_gain_rate = MagicMock(return_value=5)
+        self.strategy.calculate_price = MagicMock(return_value=mean+std_dev*times_above_mean)
+        self.strategy.update_accumulated_time = MagicMock()
+        self.strategy.update_offer = MagicMock()
+        self.strategy.time_accumulated = MAX_ACCUMULATION_TIME - 1
+
+        self.strategy.sell_reputation()
+
+        self.strategy.calculate_moving_average_data.assert_called_once()
+        self.strategy.get_available_mb.assert_called_once()
+        self.strategy.get_reputation_gain_rate.assert_called_once()
+        self.strategy.calculate_price.assert_called_once()
+        self.strategy.update_accumulated_time.assert_called_with(times_above_mean)
+        self.strategy.update_offer.assert_called_with(self.strategy.get_reputation_gain_rate(),
+                                                      ITERATION_TIME_DIFF * 60)
+
+    def test_sell_reputation_spike(self):
+        mean = 5
+        std_dev = 2
+        times_above_mean = 2
+        self.strategy.calculate_moving_average_data = MagicMock(return_value=(mean, std_dev))
+        self.strategy.get_available_mb = MagicMock(return_value=100)
+        self.strategy.get_reputation_gain_rate = MagicMock(return_value=5)
+        self.strategy.calculate_price = MagicMock(return_value=mean+std_dev*times_above_mean)
+        self.strategy.update_accumulated_time = MagicMock()
+        self.strategy.update_offer = MagicMock()
+        self.strategy.time_accumulated = MAX_ACCUMULATION_TIME - 1
+
+        self.strategy.sell_reputation()
+
+        self.strategy.calculate_moving_average_data.assert_called_once()
+        self.strategy.get_available_mb.assert_called_once()
+        self.strategy.get_reputation_gain_rate.assert_called_once()
+        self.strategy.calculate_price.assert_called_once()
+        self.strategy.update_accumulated_time.assert_called_with(times_above_mean)
+        self.strategy.update_offer.assert_called_with(self.strategy.get_reputation_gain_rate() * times_above_mean,
+                                                      ITERATION_TIME_DIFF * 60)
+
+    def test_sell_reputation_big_spike(self):
+        mean = 5
+        std_dev = 2
+        times_above_mean = 3
+        self.strategy.calculate_moving_average_data = MagicMock(return_value=(mean, std_dev))
+        self.strategy.get_available_mb = MagicMock(return_value=100)
+        self.strategy.get_reputation_gain_rate = MagicMock(return_value=5)
+        self.strategy.calculate_price = MagicMock(return_value=mean+std_dev*times_above_mean)
+        self.strategy.update_accumulated_time = MagicMock()
+        self.strategy.update_offer = MagicMock()
+        self.strategy.time_accumulated = MAX_ACCUMULATION_TIME - 1
+
+        self.strategy.sell_reputation()
+
+        self.strategy.calculate_moving_average_data.assert_called_once()
+        self.strategy.get_available_mb.assert_called_once()
+        self.strategy.get_reputation_gain_rate.assert_called_once()
+        self.strategy.calculate_price.assert_called_once()
+        self.strategy.update_accumulated_time.assert_called_with(times_above_mean)
+        self.strategy.update_offer.assert_called_with(self.strategy.get_reputation_gain_rate() * times_above_mean,
+                                                      ITERATION_TIME_DIFF * 60)
+
+    def test_sell_reputation_huge_spike(self):
+        mean = 5
+        std_dev = 2
+        times_above_mean = 5
+        self.strategy.calculate_moving_average_data = MagicMock(return_value=(mean, std_dev))
+        self.strategy.get_available_mb = MagicMock(return_value=100)
+        self.strategy.get_reputation_gain_rate = MagicMock(return_value=5)
+        self.strategy.calculate_price = MagicMock(return_value=mean+std_dev*times_above_mean)
+        self.strategy.update_accumulated_time = MagicMock()
+        self.strategy.update_offer = MagicMock()
+        self.strategy.time_accumulated = MAX_ACCUMULATION_TIME - 1
+
+        self.strategy.sell_reputation()
+
+        self.strategy.calculate_moving_average_data.assert_called_once()
+        self.strategy.get_available_mb.assert_called_once()
+        self.strategy.get_reputation_gain_rate.assert_called_once()
+        self.strategy.calculate_price.assert_called_once()
+        self.strategy.update_accumulated_time.assert_called_with(self.strategy.time_accumulated)
+        self.strategy.update_offer.assert_called_with(self.strategy.get_available_mb(),
+                                                      ITERATION_TIME_DIFF * 60)
+
+    def test_create_offer_no_provider(self):
+        amount_mb = 1
+        self.strategy = SimpleMovingAverage()
+        self.po = self.strategy.place_offer
+        self.grp = self.strategy.get_replication_price
+
+        self.strategy.place_offer = MagicMock()
+        self.strategy.get_replication_price = MagicMock()
+        self.strategy.config.get = MagicMock(return_value=None)
+
+        self.strategy.create_offer(amount_mb, plebnet_settings.TIME_IN_HOUR)
+        self.strategy.place_offer.assert_not_called()
+
+        self.strategy.place_offer = self.po
+        self.strategy.get_replication_price = self.grp
+
+    def test_create_offer_with_provider(self):
+        amount_mb = 1
+        self.strategy.place_offer = MagicMock()
+        self.strategy.config.get = MagicMock(return_value=('prov', 'opt', 'test'))
+
+        self.strategy.create_offer(amount_mb, plebnet_settings.TIME_IN_HOUR)
+        self.strategy.place_offer.assert_called_once()

--- a/tests/agent/strategies/test_simple_moving_average.py
+++ b/tests/agent/strategies/test_simple_moving_average.py
@@ -3,7 +3,7 @@ import time
 import unittest
 
 from mock.mock import MagicMock
-from sqlalchemy.testing import mock
+import mock
 
 from plebnet.agent import core
 from plebnet.agent.strategies.last_day_sell import LastDaySell

--- a/tests/agent/strategies/test_simple_moving_average.py
+++ b/tests/agent/strategies/test_simple_moving_average.py
@@ -3,6 +3,7 @@ import time
 import unittest
 
 from mock.mock import MagicMock
+from sqlalchemy.testing import mock
 
 from plebnet.agent import core
 from plebnet.agent.strategies.last_day_sell import LastDaySell
@@ -88,19 +89,19 @@ class TestSimpleMovingAverage(unittest.TestCase):
         self.strategy.apply()
         LastDaySell.apply.assert_called_once()
 
-    def test_apply(self):
+    @mock.patch("plebnet.agent.core.attempt_purchase")
+    def test_apply(self, attempt_purchase):
         initial_time = 10
         self.strategy.time_accumulated = initial_time
         self.strategy.sell_reputation = MagicMock()
         self.strategy.write_iteration_info = MagicMock()
-        core.attempt_purchase = MagicMock()
 
         self.strategy.apply()
 
         self.assertEqual(self.strategy.time_accumulated, initial_time + ITERATION_TIME_DIFF)
         self.strategy.sell_reputation.assert_called_once()
         self.strategy.write_iteration_info.assert_called_once()
-        core.attempt_purchase.assert_called_once()
+        attempt_purchase.assert_called_once()
 
     def create_transaction(self, timestamp, price=1):
         return {

--- a/tests/agent/strategies/test_strategy.py
+++ b/tests/agent/strategies/test_strategy.py
@@ -20,52 +20,52 @@ class TestStrategy(unittest.TestCase):
         def sell_reputation(self):
             pass
 
-        def create_offer(self, timeout):
+        def create_offer(self, mb_amount, timeout):
             pass
 
     def test_update_offer(self):
         timeout = plebnet_settings.TIME_IN_DAY
+        mb_amount = 100
         self.strategy = self.StrategyWrapper()
         self.create_offer = self.strategy.create_offer
         self.strategy.create_offer = MagicMock()
 
         self.strategy.config.time_since_offer = MagicMock(return_value=timeout-1)
-        self.strategy.update_offer(timeout)
+        self.strategy.update_offer(mb_amount, timeout)
         self.strategy.create_offer.assert_not_called()
 
         self.strategy.config.time_since_offer = MagicMock(return_value=timeout+1)
-        self.strategy.update_offer(timeout)
+        self.strategy.update_offer(mb_amount, timeout)
         self.strategy.create_offer.assert_called_once()
 
         self.strategy.create_offer = self.create_offer
 
     def test_place_offer_zero_mb(self):
         self.strategy = self.StrategyWrapper()
-        self.mb = market.get_balance
-        self.logger = Logger.log
 
-        Logger.log = MagicMock()
-        market.get_balance = MagicMock(return_value=0)
-        self.assertFalse(self.strategy.place_offer(5, plebnet_settings.TIME_IN_HOUR, PlebNetConfig()))
-
-        market.get_balance = self.mb
-        Logger.log = self.logger
+        self.assertFalse(self.strategy.place_offer(0, 5, plebnet_settings.TIME_IN_HOUR, PlebNetConfig()))
 
     def test_place_offer(self):
+        mb_amount = 100
         self.strategy = self.StrategyWrapper()
-        self.mb = market.get_balance
-        self.logger = Logger.log
         self.put = market.put_bid
         self.true_settings = plebnet_settings.Init.wallets_testnet
 
-        Logger.log = MagicMock()
-        market.get_balance = MagicMock(return_value=56)
         market.put_bid = MagicMock()
         plebnet_settings.Init.wallets_testnet = MagicMock(return_value=False)
 
-        self.strategy.place_offer(5, plebnet_settings.TIME_IN_HOUR, PlebNetConfig())
+        self.strategy.place_offer(mb_amount, 5, plebnet_settings.TIME_IN_HOUR, PlebNetConfig())
         market.put_bid.assert_called_once()
 
-        market.get_balance = self.mb
-        Logger.log = self.logger
         market.put_bid = self.put
+
+    def test_get_available_mb(self):
+        self.strategy = self.StrategyWrapper()
+        self.balance = market.get_balance
+        market.get_balance = MagicMock()
+
+        self.strategy.get_available_mb()
+
+        market.get_balance.assert_called_once()
+
+        market.get_balance = self.balance

--- a/tests/clone/test_server_installer.py
+++ b/tests/clone/test_server_installer.py
@@ -18,7 +18,7 @@ test_log_path = os.path.join(user_config_dir(), 'tests_logs')
 test_log_file = os.path.join(user_config_dir(), 'tests_logs/plebnet.logs')
 test_child_file = os.path.join(user_config_dir(), 'test_child_config.cfg')
 test_child_QTable_file = os.path.join(user_config_dir(), 'Child_QTable.json')
-test_bought = ('linevast', 'Advanced', 666, 0)
+test_bought = ['linevast', 'Advanced', 666, 0]
 plebnet_file = os.path.join(user_config_dir(), 'plebnet.json')
 
 test_account = Settings()


### PR DESCRIPTION
also fix other strategies' behaviour when they have more btc than needed

Needs tests - done :heavy_check_mark: 

Needs discussion: Should we assume market liquidity? So if a bid is created at last market price is it good enough to assume that it will be matched or should we check on the next iteration? - iteration checks if last iteration bid was fullfilled (and takes into account if it was fully or partially) :heavy_check_mark:  